### PR TITLE
FIX: Use busy wait for `readDigitalInputMulti` function

### DIFF
--- a/REXduino_master/Library/REXduino_master.c
+++ b/REXduino_master/Library/REXduino_master.c
@@ -273,8 +273,7 @@ void readDigitalInputMulti(long mask[], long maskByteSize)
 		commandData[i + 1] = mask[i];
 	}
 	commandData[maskByteSize + 1] = ';';
-	sent = Send(hCom, commandData, maskByteSize + 2);
-	traceSentData(maskByteSize + 2);
+	sendData(maskByteSize + 2);
 	return;
 }
 


### PR DESCRIPTION
When Linux target is used, there is slightly different behavior in the `send` function. It is necessary to use the `sendData` internal function, which tries to send the read request multiple times.